### PR TITLE
Two errors in lwot: "Leak" and disruption of cadres when no cells present

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Set up the game as usual and pick the scenario and ideology. You will then be at
 
 When you use a card for Ops you then use the command for the operation you want. For instance if you want to disrupt you enter disrupt and the Command prompt. The program will then ask what it needs to know about the disrupt.
 
-There are two timekeeping function you have to remember to use. After the Jihadist Activity Phase each turn you must enter the "plot" command so that unblocked plots are handled. And at the end of a turn you must enter the "turn" command to handle all the end of turn activities.
+There are two timekeeping function you have to remember to use. After the US Activity Phase each turn you must enter the "plot" command so that unblocked plots are handled. And at the end of a turn you must enter the "turn" command to handle all the end of turn activities.
 
 At any time you can use the "status" command to get a print out of the entire board position. And you can use the "history" command to see everything that has happened in the game.
 

--- a/lwotai.py
+++ b/lwotai.py
@@ -3046,6 +3046,8 @@ class Labyrinth(cmd.Cmd):
 			self.testCountry(country)
 			cellsToMove = min(numCells, self.cells)
 			self.map[country].sleeperCells += cellsToMove
+			# remove cadre 
+			self.map[country].cadre = 0
 			self.cells -= cellsToMove
 			self.outputToHistory("%d Sleeper Cell(s) placed in %s" % (cellsToMove, country), False)
 			self.outputToHistory(self.map[country].countryStr(), True)

--- a/lwotai.py
+++ b/lwotai.py
@@ -120,7 +120,7 @@ class Country:
 		elif self.governance == 3:
 			return "Poor"
 		elif self.governance == 4:
-			return "Islamic Rule"
+			return "Islamist Rule"
 
 	def typePretty(self, theType):
 		if theType == "Non-Muslim":
@@ -291,7 +291,7 @@ class Card:
 					return False
 				return app.numDisruptable() > 0
 			elif self.number == 35: # Hajib
-				return app.numIslamicRule() == 0
+				return app.numIslamistRule() == 0
 			elif self.number == 36: # Indo-Pakistani Talks
 				if app.map['Pakistan'].governance == 1 or app.map['Pakistan'].governance == 2:
 					return True
@@ -320,7 +320,7 @@ class Card:
 			elif self.number == 44: # Renditions
 				return (app.map["United States"].posture == "Hard") and ("Leak-Renditions" not in app.markers)
 			elif self.number == 45: # Safer Now
-				if app.numIslamicRule() > 0:
+				if app.numIslamistRule() > 0:
 					return False
 				for country in app.map:
 					if app.map[country].governance == 1:
@@ -523,7 +523,7 @@ class Card:
 						return False
 					if "Al-Anbar" in app.markers:
 						return False
-					return app.numIslamicRule() == 0
+					return app.numIslamistRule() == 0
 				else:
 					return True
 			elif self.number == 112: # Bin Ladin
@@ -532,7 +532,7 @@ class Card:
 						return False
 					if "Al-Anbar" in app.markers:
 						return False
-					return app.numIslamicRule() == 0
+					return app.numIslamistRule() == 0
 				else:
 					return True
 			elif self.number == 113: # Darfur
@@ -781,7 +781,7 @@ class Card:
 					app.changeFunding(-2, True)
 			elif self.number == 12: # Al-Azhar
 				app.testCountry("Egypt")
-				numIR = app.numIslamicRule()
+				numIR = app.numIslamistRule()
 				if numIR <= 0:
 					app.changeFunding(-4, True)
 				else:
@@ -850,7 +850,7 @@ class Card:
 						app.outputToHistory("Somalia now Poor Neutral.", False)
 						app.outputToHistory(app.map["Somalia"].countryStr(), True)
 					else:
-						print "Both Somalia and Sudan are under Islamic Rule."
+						print "Both Somalia and Sudan are under Islamist Rule."
 						if app.getYesNoFromUser("Do you want Somalia to be set to Poor Neutral? (y/n): "):
 							app.map["Somalia"].governance = 3
 							app.map["Somalia"].alignment = "Neutral"
@@ -1509,13 +1509,8 @@ class Card:
 				if app.map["United States"].posture == "Soft":
 					app.map["United States"].posture = "Hard"
 					app.outputToHistory("US Posture now Hard.", False)
-				prestigeRolls = []
-				for i in range(3):
-					prestigeRolls.append(random.randint(1,6))
-				presMultiplier = 1
-				if prestigeRolls[0] <= 4:
-					presMultiplier = -1
-				app.changePrestige(min(prestigeRolls[1], prestigeRolls[2]) * presMultiplier)
+				prestigeRoll = app.rollPrestige()
+				app.changePrestige(prestigeRoll)
 			elif self.number == 79: # Clean Operatives
 				app.handleTravel(2, False, False, True)
 			elif self.number == 80: # FATA
@@ -1572,15 +1567,11 @@ class Card:
 				app.markers.remove(target)
 				app.markers.append("Leak-"+target)
 				app.outputToHistory("%s removed and can no longer be played." % target, False)	
-				usPrestigeRolls = []
-				for i in range(3):
-					usPrestigeRolls.append(random.randint(1,6))
-				postureRoll = random.randint(1,6)
-
-				presMultiplier = 1
-				if usPrestigeRolls[0] <= 4:
-					presMultiplier = -1
-				app.changePrestige(min(usPrestigeRolls[1], usPrestigeRolls[2]) * presMultiplier, False)
+				
+				prestigeRoll = app.rollPrestige()
+				app.changePrestige(prestigeRoll)								
+				
+				postureRoll = app.getRollFromUser("Enter Prosture Roll or r to have program roll: ")
 				if postureRoll <= 4:
 					app.map["United States"].posture = "Soft"
 				else:
@@ -1598,7 +1589,7 @@ class Card:
 			elif self.number == 87 or self.number == 88 or self.number == 89: # Martyrdom Operation
 				if app.executePlot(1, False, [1], True) == 1:
 					app.outputToHistory("No plots could be placed.", True)
-					self.handleRadicalization(self.deck[str(self.number)].ops)					
+					app.handleRadicalization(app.deck[str(self.number)].ops)					
 			elif self.number == 90: # Quagmire
 				app.map["United States"].posture = "Soft"
 				app.outputToHistory("US Posture now Soft.", False)
@@ -1657,7 +1648,7 @@ class Card:
 							possibles.append(country)
 				target = random.choice(possibles)
 				app.testCountry(target)
-				if app.numIslamicRule() > 0:
+				if app.numIslamistRule() > 0:
 					app.outputToHistory("Place any available plot in %s." % target, False)
 				else:
 					app.outputToHistory("Place a Plot 1 in %s." % target, False)
@@ -1973,13 +1964,10 @@ class Card:
 						target = random.choice(possibles)
 				app.removeCell(target)
 				app.removeCell(target)
-				prestigeRolls = []
-				for i in range(3):
-					prestigeRolls.append(random.randint(1,6))
-				presMultiplier = 1
-				if prestigeRolls[0] <= 4:
-					presMultiplier = -1
-				app.changePrestige(min(prestigeRolls[1], prestigeRolls[2]) * presMultiplier)
+
+				prestigeRoll = app.rollPrestige()
+				app.changePrestige(prestigeRoll)								
+
 			elif self.number == 110: # Zarqawi
 				if side == "US":
 					app.changePrestige(3)
@@ -1998,7 +1986,7 @@ class Card:
 				if side == "US":
 					app.changeFunding(-2)
 				else:
-					if app.numIslamicRule() > 0:
+					if app.numIslamistRule() > 0:
 						app.changePrestige(-3)
 					else:
 						app.changePrestige(-1)
@@ -2008,7 +1996,7 @@ class Card:
 					app.changePrestige(1)
 					app.outputToHistory("Remove card from game.", False)
 				else:
-					if app.numIslamicRule() > 0:
+					if app.numIslamistRule() > 0:
 						app.changePrestige(-4)
 					else:
 						app.changePrestige(-2)
@@ -2036,13 +2024,9 @@ class Card:
 			elif self.number == 114: # GTMO
 				app.lapsing.append("GTMO")
 				app.outputToHistory("GTMO in play. No recruit operations or Detainee Release the rest of this turn.", False)
-				prestigeRolls = []
-				for i in range(3):
-					prestigeRolls.append(random.randint(1,6))
-				presMultiplier = 1
-				if prestigeRolls[0] <= 4:
-					presMultiplier = -1
-				app.changePrestige(min(prestigeRolls[1], prestigeRolls[2]) * presMultiplier)								
+				prestigeRoll = app.rollPrestige()
+				app.changePrestige(prestigeRoll)								
+			
 			elif self.number == 115: # Hambali
 				if side == "US":
 					possibles = ["Indonesia/Malaysia"]
@@ -2621,10 +2605,10 @@ class Labyrinth(cmd.Cmd):
 				elif self.map[country].posture == "Soft":
 					worldPos -= 1
 		print "Good Resources   : %d" % goodRes
-		print "Islamic Resources: %d" % islamRes
+		print "Islamist Resources: %d" % islamRes
 		print "---"
 		print "Good/Fair Countries   : %d" % goodC
-		print "Poor/Islamic Countries: %d" % islamC
+		print "Poor/Islamist Countries: %d" % islamC
 		print ""
 		print "GWOT"
 		print "US Posture: %s" % self.map["United States"].posture
@@ -3023,6 +3007,28 @@ class Labyrinth(cmd.Cmd):
 		else:
 			return 0
 			
+	def rollPrestige(self):
+
+		prestigeRolls = []			
+
+		prestigeRolls.append(self.getRollFromUser("Enter first unmodified prestige roll (ignore GWOT) or r to have program roll: "))
+		if self.gwotPenalty() < 0:			
+			self.outputToHistory("GWOT Relations Penalty -1 modifier in effect.", False)
+			prestigeRolls[0] = prestigeRolls[0] - 1
+			
+		prestigeRolls.append(self.getRollFromUser("Enter Prestige Roll 1 or r to have program roll: "))
+		prestigeRolls.append(self.getRollFromUser("Enter Prestige Roll 2 or r to have program roll: "))
+					
+		presMultiplier = 1
+		if prestigeRolls[0] <= 4:
+			presMultiplier = -1
+			self.outputToHistory("First Prestige roll <= 4.  Prestige will drop.", False)
+		else:
+			self.outputToHistory("First Prestige roll >= 5.  Prestige will rise.", False)
+
+		return min(prestigeRolls[1], prestigeRolls[2]) * presMultiplier
+		
+	
 	def changePrestige(self, delta, lineFeed = True):
 		self.prestige += delta
 		if self.prestige < 1:
@@ -3111,7 +3117,7 @@ class Labyrinth(cmd.Cmd):
 			retVal -= 5
 		return max(retVal, 0)
 		
-	def numIslamicRule(self):
+	def numIslamistRule(self):
 		numIR = 0
 		for country in self.map:
 			if self.map[country].governance == 4:
@@ -3186,7 +3192,7 @@ class Labyrinth(cmd.Cmd):
 			self.map["United States"].posture = "Hard"
 		self.outputToHistory("* Reassessment = US Posture now %s" % self.map["United States"].posture)
 		
-	def handleRegimeChange(self, where, moveFrom, howMany, govRoll, prestigeRolls):
+	def handleRegimeChange(self, where, moveFrom, howMany, govRoll, prestigeRoll):
 		if self.map["United States"].posture == "Soft":
 			return
 		if moveFrom == 'track':
@@ -3203,10 +3209,7 @@ class Labyrinth(cmd.Cmd):
 		else:
 			self.map[where].governance = 2
 		self.map[where].regimeChange = 1
-		presMultiplier = 1
-		if prestigeRolls[0] <= 4:
-			presMultiplier = -1
-		self.changePrestige(min(prestigeRolls[1], prestigeRolls[2]) * presMultiplier)
+		self.changePrestige(prestigeRoll)
 		self.outputToHistory("* Regime Change in %s" % where, False)
 		self.outputToHistory(self.map[where].countryStr(), False)
 		if moveFrom == "track":
@@ -3221,7 +3224,7 @@ class Labyrinth(cmd.Cmd):
 			self.markers.remove("Libyan WMD")
 			self.outputToHistory("Libyan WMD no longer in play.", True)
 		
-	def handleWithdraw(self, moveFrom, moveTo, howMany, prestigeRolls):
+	def handleWithdraw(self, moveFrom, moveTo, howMany, prestigeRoll):
 		if self.map["United States"].posture == "Hard":
 			return
 		self.map[moveFrom].changeTroops(-howMany)
@@ -3231,10 +3234,8 @@ class Labyrinth(cmd.Cmd):
 			self.map[moveTo].changeTroops(howMany)
 		self.map[moveFrom].aid = 0
 		self.map[moveFrom].besieged = 1
-		presMultiplier = 1
-		if prestigeRolls[0] <= 4:
-			presMultiplier = -1
-		self.changePrestige(min(prestigeRolls[1], prestigeRolls[2]) * presMultiplier)
+
+		self.changePrestige(prestigeRoll)
 		self.outputToHistory("* Withdraw troops from %s" % moveFrom, False)
 		self.outputToHistory(self.map[moveFrom].countryStr(), False)
 		if moveTo == "track":
@@ -3344,6 +3345,7 @@ class Labyrinth(cmd.Cmd):
 	def executeJihad(self, country, rollList):
 		successes = 0
 		failures = 0
+		majorJihadFailure = False
 		for roll in rollList:
 			if roll <= self.map[country].governance:
 				successes += 1
@@ -3358,6 +3360,7 @@ class Labyrinth(cmd.Cmd):
 			self.map[country].activeCells += sleepers
 			self.outputToHistory("All cells go Active", False)
 			if ((failures >= 2  and self.map[country].besieged == 0) or (failures == 3 and self.map[country].besieged == 1))  and (len(rollList) == 3) and self.map[country].governance == 3:
+				majorJihadFailure = True
 				self.outputToHistory("Major Jihad Failure", False) 
 				self.map[country].besieged = 1
 				self.outputToHistory("Besieged Regime", False) 
@@ -3377,10 +3380,10 @@ class Labyrinth(cmd.Cmd):
 			successes -= 1
 			self.outputToHistory("Governance to %s" % self.map[country].govStr(), False)
 			self.map[country].aid = 0
-		if isMajorJihad and ((successes >= 2) or ((self.map[country].besieged > 0) and (successes >= 1))) : # Major Jihad
-			self.outputToHistory("Islamic Revolution in %s" % country, False) 
+		if isMajorJihad and (not majorJihadFailure) and ((successes >= 2) or ((self.map[country].besieged > 0) and (successes >= 1))) : # Major Jihad
+			self.outputToHistory("Islamist Revolution in %s" % country, False) 
 			self.map[country].governance = 4
-			self.outputToHistory("Governance to Islamic Rule", False) 
+			self.outputToHistory("Governance to Islamist Rule", False) 
 			self.map[country].alignment = "Adversary"
 			self.outputToHistory("Alingment to Adversary", False) 
 			self.map[country].regimeChange = 0
@@ -3510,21 +3513,34 @@ class Labyrinth(cmd.Cmd):
 					break
 			return returnList
 			
-	def recruitChoice(self, isMadrassas = False):
+	def recruitChoice(self, ops, isMadrassas = False):
+		
+		self.debugPrint("DEBUG: recruit with remaining %d ops" % ops)
+
+		self.debugPrint("DEBUG: recruit with remaining %d ops" % (2*ops))
+
+		
 		countryScores = {}
 		for country in self.map:
+			
+			
 			if (self.map[country].totalCells(True) > 0 or (self.map[country].cadre > 0)) or (isMadrassas and self.map[country].governance > 2):
-				countryScores[country] = 0
+				#countryScores[country] = 0
 				if (self.map[country].regimeChange > 0) and (self.map[country].troops() - self.map[country].totalCells(True)) >= 5:
-					countryScores[country] += 100000000
-				elif ((self.map[country].governance == 4) and (self.map[country].totalCells(True) < (2 * self.countryResources(country)))):
-					countryScores[country] += 10000000
+					self.debugPrint("a")
+					countryScores[country] = 100000000
+				elif ((self.map[country].governance == 4) and (self.map[country].totalCells(True) < (2 * ops))):
+					davex = self.map[country].totalCells(True)
+					self.debugPrint("here: recruit with remaining %d ops" % davex)
+					countryScores[country] = 10000000
 				elif (self.map[country].governance != 4) and (self.map[country].regimeChange <= 0):
+					self.debugPrint("b")
 					if self.map[country].recruit > 0:
-						countryScores[country] += (self.map[country].recruit * 1000000)
+						countryScores[country] = (self.map[country].recruit * 1000000)
 					else:
-						countryScores[country] += (self.map[country].governance * 1000000)
+						countryScores[country] = (self.map[country].governance * 1000000)
 		for country in countryScores:
+			self.debugPrint("c")
 			if self.map[country].besieged > 0:
 				countryScores[country] += 100000
 			countryScores[country] += (1000 * (self.map[country].troops() + self.map[country].totalCells(True)))
@@ -3532,12 +3548,16 @@ class Labyrinth(cmd.Cmd):
 			countryScores[country] += random.randint(1,99)
 		countryOrder = []
 		for country in countryScores:
-			countryOrder.append((countryScores[country], (self.map[country].totalCells(True)), country))
+			self.debugPrint("here: %d " % countryScores[country])
+			if countryScores[country] > 0:
+				countryOrder.append((countryScores[country], (self.map[country].totalCells(True)), country))
 		countryOrder.sort()
 		countryOrder.reverse()
 		if countryOrder == []:
+			self.debugPrint("d")
 			return False
 		else:
+			self.debugPrint("e")
 			return countryOrder[0][2]
 	
 	def executeRecruit(self, country, ops, rolls, recruitOverride = None, isJihadistVideos = False, isMadrassas = False):
@@ -3553,7 +3573,7 @@ class Labyrinth(cmd.Cmd):
 			if self.map[country].regimeChange:
 				self.outputToHistory("Recruit to Regime Change country automatically successful.", False)
 			else:
-				self.outputToHistory("Recruit to Islamic Rule country automatically successful.", False)
+				self.outputToHistory("Recruit to Islamist Rule country automatically successful.", False)
 			self.cells -= cellsToRecruit
 			self.map[country].sleeperCells += cellsToRecruit
 			
@@ -3608,7 +3628,9 @@ class Labyrinth(cmd.Cmd):
 				return opsRemaining
 					
 	def handleRecruit(self, ops, isMadrassas = False):
-		country = self.recruitChoice(isMadrassas)
+		self.debugPrint("recruit ops: ")
+		self.debugPrint("DEBUG: recruit with remaining %d ops" % ops)
+		country = self.recruitChoice(ops, isMadrassas)
 		if not country:
 			self.outputToHistory("* No countries qualify to Recruit.", True)
 			return ops
@@ -4282,7 +4304,7 @@ class Labyrinth(cmd.Cmd):
 				self.outputToHistory(self.map[location].countryStr(), True)
 				opsRemaining -= 1
 						
-	def resolvePlot(self, country, plotType, postureRoll, usPrestigeRolls, schCountries, schPostureRolls, govRolls, isBacklash = False):
+	def resolvePlot(self, country, plotType, postureRoll, usPrestigeRoll, schCountries, schPostureRolls, govRolls, isBacklash = False):
 		self.outputToHistory("--> Resolve \"%s\" plot in %s" % (str(plotType), country), False)
 		if country == "United States":
 			if plotType == "WMD":
@@ -4291,11 +4313,7 @@ class Labyrinth(cmd.Cmd):
 			else:
 				self.funding = 9
 				self.outputToHistory("Jihadist Funding now 9", False)
-				presMultiplier = 1
-				if usPrestigeRolls[0] <= 4:
-					presMultiplier = -1
-				self.changePrestige(min(usPrestigeRolls[1], usPrestigeRolls[2]) * presMultiplier)
-				self.outputToHistory("US Prestige now %d" % self.prestige, False)	
+				self.changePrestige(usPrestigeRoll)
 				if postureRoll <= 4:
 					self.map["United States"].posture = "Soft"
 				else:
@@ -4359,11 +4377,12 @@ class Labyrinth(cmd.Cmd):
 				else:
 					self.changeFunding(plotType)
 			self.outputToHistory("Jihadist Funding now %d" % self.funding, False)
-			if postureRoll <= 4:
-				self.map[country].posture = "Soft"
-			else:
-				self.map[country].posture = "Hard"
-			self.outputToHistory("%s Posture now %s" % (country, self.map[country].posture), True)
+			if country != "Israel":
+				if postureRoll <= 4:
+					self.map[country].posture = "Soft"
+				else:
+					self.map[country].posture = "Hard"
+				self.outputToHistory("%s Posture now %s" % (country, self.map[country].posture), True)
 
 			if self.map[country].troops() > 0:
 				if plotType == "WMD":
@@ -4498,7 +4517,7 @@ class Labyrinth(cmd.Cmd):
 				
 	def executeCardEuroIslam(self, posStr):
 		self.map["Benelux"].posture = posStr
-		if self.numIslamicRule() == 0:
+		if self.numIslamistRule() == 0:
 			self.funding -= 1
 			if self.funding < 1:
 				self.funding = 1
@@ -4582,7 +4601,7 @@ class Labyrinth(cmd.Cmd):
 		print "War of Ideas Eligible Countries"
 		print "-------------------------------"
 		for country in self.map:
-			if self.map[country].alignment == "Neutral" or self.map[country].alignment == "Ally":
+			if self.map[country].alignment == "Neutral" or self.map[country].alignment == "Ally" or self.map[country].governance == 0:
 				print "%s, %s %s - %d Active Cells, %d Sleeper Cells, %d Cadre, %d troops" % (country, self.map[country].govStr(), self.map[country].alignment, self.map[country].activeCells, self.map[country].sleeperCells, self.map[country].cadre, self.map[country].troops())
 		for country in self.map:
 			if self.map[country].type == "Non-Muslim" and country != "United States" and self.map[country].posture == "Hard":
@@ -4603,9 +4622,9 @@ class Labyrinth(cmd.Cmd):
 				self.map[country].printCountry()
 		print ""
 		
-	def listIslamicCountries(self, na = None):
+	def listIslamistCountries(self, na = None):
 		print ""
-		print "Islamic Rule Countries"
+		print "Islamist Rule Countries"
 		print "----------------------"
 		for country in self.map:
 			if self.map[country].governance == 4:
@@ -4818,7 +4837,7 @@ class Labyrinth(cmd.Cmd):
 		if not num:
 			print "none"
 		print ""
-		print "ISLAMIC RULE"
+		print "ISLAMIST RULE"
 		num = 0
 		for country in self.map:
 			if self.map[country].type != "Non-Muslim" and self.map[country].governance == 4:
@@ -4856,10 +4875,10 @@ class Labyrinth(cmd.Cmd):
 		print ""
 		print "VICTORY"
 		print "Good Resources   : %d" % goodRes
-		print "Islamic Resources: %d" % islamRes
+		print "Islamist Resources: %d" % islamRes
 		print "---"
 		print "Good/Fair Countries   : %d" % goodC
-		print "Poor/Islamic Countries: %d" % islamC
+		print "Poor/Islamist Countries: %d" % islamC
 		print ""
 		print "GWOT"
 		print "US Posture: %s" % self.map["United States"].posture
@@ -5056,10 +5075,10 @@ class Labyrinth(cmd.Cmd):
 			else:
 				if self.map[input].type == "Non-Muslim" and input != "United States":
 					where = input
-				elif self.map[input].alignment == "Ally" or self.map[input].alignment == "Neutral":
+				elif self.map[input].alignment == "Ally" or self.map[input].alignment == "Neutral" or self.map[input].governance == 0:
 					where = input
 				else:
-					print "Country not elligable for War of Ideas."
+					print "Country not eligible for War of Ideas."
 					print ""
 		if self.map[where].type == "Non-Muslim" and input != "United States": # Non-Muslim
 			postureRoll = self.getRollFromUser("Enter Posture Roll or r to have program roll: ")
@@ -5080,6 +5099,7 @@ class Labyrinth(cmd.Cmd):
 						self.prestige = 12
 					self.outputToHistory("US Prestige now %d" % self.prestige)
 		else: # Muslim
+			self.testCountry(where)
 			woiRoll = self.getRollFromUser("Enter WoI roll or r to have program roll: ")
 			modRoll = self.modifiedWoIRoll(woiRoll, where)
 			self.outputToHistory("Modified Roll: %d" % modRoll)
@@ -5131,7 +5151,7 @@ class Labyrinth(cmd.Cmd):
 			return
 		where = None
 		while not where:
-			input = self.getCountryFromUser("Regime Change in what country?  (? for list): ", "XXX", self.listIslamicCountries)
+			input = self.getCountryFromUser("Regime Change in what country?  (? for list): ", "XXX", self.listIslamistCountries)
 			if input == "":
 				print ""
 				return
@@ -5139,7 +5159,7 @@ class Labyrinth(cmd.Cmd):
 				if (self.map[input].governance == 4) or (input == "Iraq" and "Iraqi WMD" in self.markers) or (input == "Libya" and "Libyan WMD" in self.markers):
 					where = input
 				else:
-					print "Country not Islamic Rule."
+					print "Country not Islamist Rule."
 					print ""
 		moveFrom = None
 		available = 0
@@ -5179,10 +5199,9 @@ class Labyrinth(cmd.Cmd):
 			else:
 				howMany = input
 		govRoll = self.getRollFromUser("Enter Governance roll or r to have program roll: ")
-		preFirstRoll = self.getRollFromUser("Enter first die (Raise/Drop) for Prestige roll or r to have program roll: ")
-		preSecondRoll = self.getRollFromUser("Enter second die for Prestige roll or r to have program roll: ")
-		preThirdRoll = self.getRollFromUser("Enter thrid die for Prestige roll or r to have program roll: ")
-		self.handleRegimeChange(where, moveFrom, howMany, govRoll, (preFirstRoll, preSecondRoll, preThirdRoll))
+		
+		prestigeRoll = self.rollPrestige()		
+		self.handleRegimeChange(where, moveFrom, howMany, govRoll, prestigeRoll)
 		
 	def help_regime(self):
 		print "Regime Change in Islamist Rule Country."
@@ -5234,10 +5253,9 @@ class Labyrinth(cmd.Cmd):
 				return
 			else:
 				howMany = input
-		preFirstRoll = self.getRollFromUser("Enter first die (Raise/Drop) for Prestige roll or r to have program roll: ")
-		preSecondRoll = self.getRollFromUser("Enter second die for Prestige roll or r to have program roll: ")
-		preThirdRoll = self.getRollFromUser("Enter thrid die for Prestige roll or r to have program roll: ")
-		self.handleWithdraw(moveFrom, moveTo, howMany, (preFirstRoll, preSecondRoll, preThirdRoll))
+		
+		prestigeRoll = self.rollPrestige()		
+		self.handleWithdraw(moveFrom, moveTo, howMany, prestigeRoll)
 
 	def help_withdraw(self):
 		print "Withdraw Troops from Regime Change Country."
@@ -5374,10 +5392,12 @@ class Labyrinth(cmd.Cmd):
 				govRolls = []
 				if country == "United States":
 					if plotType != "WMD":
-						postureRoll = random.randint(1,6)
-						usPrestigeRolls.append(random.randint(1,6))
-						usPrestigeRolls.append(random.randint(1,6))
-						usPrestigeRolls.append(random.randint(1,6))
+						postureRoll = self.getRollFromUser("Enter Posture Roll or r to have program roll: ")
+
+						usPrestigeRoll = self.rollPrestige()		
+
+				
+				
 				elif self.map[country].type != "Non-Muslim":
 					if country != "Iran":
 						numRolls = 0
@@ -5388,7 +5408,7 @@ class Labyrinth(cmd.Cmd):
 						for i in range(numRolls):
 							govRolls.append(random.randint(1,6))
 				elif self.map[country].type == "Non-Muslim":
-					postureRoll = random.randint(1,6)
+					postureRoll = self.getRollFromUser("Enter Posture Roll or r to have program roll: ")
 					if self.map[country].schengen: 
 						schChoices = []
 						for cou in self.map:
@@ -5399,8 +5419,8 @@ class Labyrinth(cmd.Cmd):
 						while schCountries[0] == schCountries[1]:
 							schCountries[1] = random.choice(schChoices)
 						for i in range(2):
-							schPostureRolls.append(random.randint(1,6))
-				self.resolvePlot(country, plotType, postureRoll, usPrestigeRolls, schCountries, schPostureRolls, govRolls, isBacklash)
+							schPostureRolls.append(self.getRollFromUser("Enter Posture Roll or r to have program roll: "))
+				self.resolvePlot(country, plotType, postureRoll, usPrestigeRoll, schCountries, schPostureRolls, govRolls, isBacklash)
 		if not foundPlot:		
 			self.outputToHistory("", False)
 			self.outputToHistory("[[ No unblocked plots to resolve ]]", True)
@@ -5429,7 +5449,7 @@ class Labyrinth(cmd.Cmd):
 			self.prestige -= 1
 			if self.prestige < 1:
 				self.prestige = 1
-		self.outputToHistory("Islamic Rule - US Prestige now %d" % self.prestige, False)
+		self.outputToHistory("Islamist Rule - US Prestige now %d" % self.prestige, False)
 		worldPos = 0
 		for country in self.map:
 			if not (self.map[country].type == "Shia-Mix" or self.map[country].type == "Suni") and self.map[country].type != "Iran" and self.map[country].name != "United States":
@@ -5464,10 +5484,10 @@ class Labyrinth(cmd.Cmd):
 					islamRes += self.countryResources(country)
 		self.outputToHistory("---", False)
 		self.outputToHistory("Good Resources   : %d" % goodRes, False)
-		self.outputToHistory("Islamic Resources: %d" % islamRes, False)
+		self.outputToHistory("Islamist Resources: %d" % islamRes, False)
 		self.outputToHistory("---", False)
 		self.outputToHistory("Good/Fair Countries   : %d" % goodC, False)
-		self.outputToHistory("Poor/Islamic Countries: %d" % islamC, False)
+		self.outputToHistory("Poor/Islamist Countries: %d" % islamC, False)
 		self.turn += 1
 		self.outputToHistory("---", False)
 		self.outputToHistory("", False)

--- a/lwotai.py
+++ b/lwotai.py
@@ -138,6 +138,11 @@ class Country:
 			markersStr = "\n   Markers: %s" % ", ".join(self.markers)
 		if self.type == "Shia-Mix" or self.type == "Suni":
 			return "%s, %s %s, %d Resource(s)\n   Troops:%d Active:%d Sleeper:%d Cadre:%d Aid:%d Besieged:%d Reg Ch:%d Plots:%d %s" % (self.name, self.govStr(),self.alignment,self.app.countryResources(self.name),self.troops(),self.activeCells,self.sleeperCells, self.cadre, self.aid, self.besieged, self.regimeChange, self.plots, markersStr)
+
+		elif self.name == "Philippines":
+			return "%s - Posture:%s\n   Troops:%d Active:%d Sleeper:%d Cadre:%d Plots:%d %s" % (self.name,self.posture, self.troops(), self.activeCells,self.sleeperCells, self.cadre, self.plots, markersStr)
+
+
 		elif self.type == "Non-Muslim" and self.type != "United States":
 			return "%s - Posture:%s\n   Active:%d Sleeper:%d Cadre:%d Plots:%d %s" % (self.name,self.posture, self.activeCells,self.sleeperCells, self.cadre, self.plots, markersStr)
 		elif self.type == "Iran":
@@ -340,7 +345,7 @@ class Card:
 			if self.number == 48: # Adam Gadahn
 				if app.numCellsAvailable() <= 0:
 					return False
-				return app.getYesNoFromUser("Is this the 1st card of the Johadist Action Phase? (y/n): ")
+				return app.getYesNoFromUser("Is this the 1st card of the Jihadist Action Phase? (y/n): ")
 			elif self.number == 49: # Al-Ittihad al-Islami
 				return True
 			elif self.number == 50: # Ansar al-Islam
@@ -354,7 +359,7 @@ class Card:
 							return True
 				return False
 			elif self.number == 53: # Madrassas
-				return app.getYesNoFromUser("Is this the 1st card of the Johadist Action Phase? (y/n): ")
+				return app.getYesNoFromUser("Is this the 1st card of the Jihadist Action Phase? (y/n): ")
 			elif self.number == 54: # Moqtada al-Sadr
 				return app.map["Iraq"].troops() > 0
 			elif self.number == 55: # Uyghur Jihad
@@ -1593,6 +1598,7 @@ class Card:
 			elif self.number == 87 or self.number == 88 or self.number == 89: # Martyrdom Operation
 				if app.executePlot(1, False, [1], True) == 1:
 					app.outputToHistory("No plots could be placed.", True)
+					self.handleRadicalization(self.deck[str(self.number)].ops)					
 			elif self.number == 90: # Quagmire
 				app.map["United States"].posture = "Soft"
 				app.outputToHistory("US Posture now Soft.", False)
@@ -3300,17 +3306,17 @@ class Labyrinth(cmd.Cmd):
 					disStr = None
 					while not disStr:
 						if self.map[where].sleeperCells >= 2 and self.map[where].activeCells >= 2:
-							input = self.my_raw_input("You can disrupt two cells. Enter aa, as, or ss for active or slepper cells: ")
+							input = self.my_raw_input("You can disrupt two cells. Enter aa, as, or ss for active or sleeper cells: ")
 							input = input.lower()
 							if input == "aa" or input == "as" or input == "sa" or input == "ss":
 								disStr = input
 						elif self.map[where].sleeperCells >= 2:
-							input = self.my_raw_input("You can disrupt two cells. Enter as, or ss for active or slepper cells: ")
+							input = self.my_raw_input("You can disrupt two cells. Enter as, or ss for active or sleeper cells: ")
 							input = input.lower()
 							if input == "as" or input == "sa" or input == "ss":
 								disStr = input
 						elif self.map[where].activeCells >= 2:
-							input = self.my_raw_input("You can disrupt two cells. Enter aa, or as for active or slepper cells: ")
+							input = self.my_raw_input("You can disrupt two cells. Enter aa, or as for active or sleeper cells: ")
 							input = input.lower()
 							if input == "as" or input == "sa" or input == "aa":
 								disStr = input
@@ -4356,6 +4362,17 @@ class Labyrinth(cmd.Cmd):
 			else:
 				self.map[country].posture = "Hard"
 			self.outputToHistory("%s Posture now %s" % (country, self.map[country].posture), True)
+
+			if self.map[country].troops() > 0:
+				if plotType == "WMD":
+					self.prestige = 1
+				else:
+					self.prestige -= 1
+				if self.prestige < 1:
+					self.prestige = 1
+				self.outputToHistory("Troops present so US Prestige now %d" % self.prestige, False)
+
+
 			if self.map[country].schengen:
 				for i in range(len(schCountries)):
 					if schPostureRolls[i] <= 4:
@@ -5049,19 +5066,17 @@ class Labyrinth(cmd.Cmd):
 				self.outputToHistory("* War of Ideas in %s - Posture Hard" % where)
 				if self.map["United States"].posture == "Hard":
 					self.prestige += 1
-					if self.prestige > 9:
-						self.prestige = 9
-					else:
-						self.outputToHistory("US Prestige now %d" % self.prestige)
+					if self.prestige > 12:
+						self.prestige = 12
+					self.outputToHistory("US Prestige now %d" % self.prestige)
 			else:
 				self.map[where].posture = "Soft"
 				self.outputToHistory("* War of Ideas in %s - Posture Soft" % where)
 				if self.map["United States"].posture == "Soft":
 					self.prestige += 1
-					if self.prestige > 9:
-						self.prestige = 9
-					else:
-						self.outputToHistory("US Prestige now %d" % self.prestige)
+					if self.prestige > 12:
+						self.prestige = 12
+					self.outputToHistory("US Prestige now %d" % self.prestige)
 		else: # Muslim
 			woiRoll = self.getRollFromUser("Enter WoI roll or r to have program roll: ")
 			modRoll = self.modifiedWoIRoll(woiRoll, where)


### PR DESCRIPTION
I hope I'm leaving this in the right place. I am new to GitHub. I am also not a python programmer but I think I have fixed two errors in the program.
1.  The event for cards 84 & 85 (“Leak”) require an ally be changed to neutral. I borrowed the code from card 76 to do this.

elif self.number == 84 or self.number == 85: # Leak
                possibles = []
                if "Enhanced Measures" in app.markers:
                    possibles.append("Enhanced Measures")
                if "Renditions" in app.markers:
                    possibles.append("Renditions")
                if "Wiretapping" in app.markers:
                    possibles.append("Wiretapping")
                target = random.choice(possibles)
                app.markers.remove(target)
                app.markers.append("Leak-"+target)
                app.outputToHistory("%s removed and can no longer be played." % target, False)  
                usPrestigeRolls = []
                for i in range(3):
                    usPrestigeRolls.append(random.randint(1,6))
                postureRoll = random.randint(1,6)

```
            presMultiplier = 1
            if usPrestigeRolls[0] <= 4:
                presMultiplier = -1
            app.changePrestige(min(usPrestigeRolls[1], usPrestigeRolls[2]) * presMultiplier, False)
            if postureRoll <= 4:
                app.map["United States"].posture = "Soft"
            else:
                app.map["United States"].posture = "Hard"
            app.outputToHistory("US Posture now %s" % app.map["United States"].posture, True)
            allys = app.minorJihadInGoodFairChoice(1, True)    # amended here: this starts lines copied from card 76
            if not allys:
                app.outputToHistory("No Allys to shift.", True)
            else:
                target = allys[0][0]
                app.map[target].alignment = "Neutral"
                app.outputToHistory("%s Alignment shifted to Neutral." % target, True)  # end lines copied from 76
```
1. When cadres were present without cells the disrupt operation was non-functional when Al Anbar was active. This came alive when I modified the end of the ouputToHistory function to include “, False)” . But it looked also to me like the conditions to the statement needed to be added to include the case when Al Anbar was active but “where” was not Syria or Iraq. I made those 2 changes to the handledisrupt() function.

def handleDisrupt(self, where):
        numToDisrupt = 1
        if "Al-Anbar" in self.markers and (where == "Iraq" or where == "Syria"):
            numToDisrupt = 1
        elif self.map[where].troops() >= 2 or self.map[where].posture == "Hard":
            numToDisrupt = min(2, self.map[where].totalCells(False))
        if self.map[where].totalCells(False) <= 0 and self.map[where].cadre > 0:   #  this was the original following line if "Al-Anbar" not in self.markers:
            if "Al-Anbar" not in self.markers or (where != "Iraq" and where != "Syria"):    # this is the new line
                self.outputToHistory("\* Cadre removed in %s" % where, False)     # this was added to the line", False"
                self.map[where].cadre = 0
