### PR TITLE
Restored card 102 test to US Playable

### DIFF
--- a/lwotai.py
+++ b/lwotai.py
@@ -515,6 +515,7 @@ class Card:
 				return True
 			elif self.number == 101: # Kosovo
 				return True
+			elif self.number == 102: # Former Soviet Union
 				return True
 			elif self.number == 103: # Hizballah
 				return True


### PR DESCRIPTION
Previous commit of ca160d79 removed the
card 102 (Former Soviet Union) test from US playable
